### PR TITLE
Add sheets.insertText feature

### DIFF
--- a/workspace-server/src/__tests__/services/SheetsService.test.ts
+++ b/workspace-server/src/__tests__/services/SheetsService.test.ts
@@ -41,6 +41,7 @@ describe('SheetsService', () => {
         get: jest.fn(),
         values: {
           get: jest.fn(),
+          update: jest.fn(),
         },
       },
     };
@@ -430,6 +431,54 @@ describe('SheetsService', () => {
       const response = JSON.parse(result.content[0].text);
 
       expect(response.error).toBe('Metadata Error');
+    });
+  });
+
+  describe('insertText', () => {
+    it('should insert text into a specific cell', async () => {
+      const mockResponse = {
+        data: {
+          spreadsheetId: 'test-id',
+          updatedRange: 'Sheet1!A1',
+          updatedCells: 1,
+        },
+      };
+
+      mockSheetsAPI.spreadsheets.values.update.mockResolvedValue(mockResponse);
+
+      const result = await sheetsService.insertText({
+        spreadsheetId: 'test-id',
+        range: 'Sheet1!A1',
+        value: 'Hello',
+      });
+
+      expect(mockSheetsAPI.spreadsheets.values.update).toHaveBeenCalledWith({
+        spreadsheetId: 'test-id',
+        range: 'Sheet1!A1',
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values: [['Hello']],
+        },
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.updatedRange).toBe('Sheet1!A1');
+      expect(response.updatedCells).toBe(1);
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockSheetsAPI.spreadsheets.values.update.mockRejectedValue(
+        new Error('API Error'),
+      );
+
+      const result = await sheetsService.insertText({
+        spreadsheetId: 'test-id',
+        range: 'A1',
+        value: 'test',
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toBe('API Error');
     });
   });
 });

--- a/workspace-server/src/__tests__/utils/logger.test.ts
+++ b/workspace-server/src/__tests__/utils/logger.test.ts
@@ -56,7 +56,7 @@ describe('logger', () => {
   describe('module initialization', () => {
     it('should create log directory on module load', async () => {
       // Set up mocks
-      jest.doMock('fs/promises', () => ({
+      jest.doMock('node:fs/promises', () => ({
         mkdir: jest.fn(() => Promise.resolve()),
         appendFile: jest.fn(() => Promise.resolve()),
       }));
@@ -65,21 +65,24 @@ describe('logger', () => {
       await import('../../utils/logger');
 
       // Get the mocked fs module
-      fs = await import('node:fs/promises');
+      const mockedFs = await import('node:fs/promises');
 
-      // Wait for async initialization
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for async initialization - increased timeout for CI stability
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
-      expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining('logs'), {
-        recursive: true,
-      });
-    });
+      expect(mockedFs.mkdir).toHaveBeenCalledWith(
+        expect.stringContaining('logs'),
+        {
+          recursive: true,
+        },
+      );
+    }, 15000); // Increase test timeout
 
     it('should handle directory creation errors gracefully', async () => {
       const mkdirError = new Error('Permission denied');
 
       // Set up mocks
-      jest.doMock('fs/promises', () => ({
+      jest.doMock('node:fs/promises', () => ({
         mkdir: jest.fn(() => Promise.reject(mkdirError)),
         appendFile: jest.fn(() => Promise.resolve()),
       }));
@@ -87,14 +90,14 @@ describe('logger', () => {
       // Import the module
       await import('../../utils/logger');
 
-      // Wait for async initialization
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for async initialization - increased timeout for CI stability
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Could not create log directory:',
         mkdirError,
       );
-    });
+    }, 15000); // Increase test timeout
   });
 
   describe('logToFile', () => {

--- a/workspace-server/src/__tests__/utils/logger.test.ts
+++ b/workspace-server/src/__tests__/utils/logger.test.ts
@@ -56,7 +56,7 @@ describe('logger', () => {
   describe('module initialization', () => {
     it('should create log directory on module load', async () => {
       // Set up mocks
-      jest.doMock('node:fs/promises', () => ({
+      jest.doMock('fs/promises', () => ({
         mkdir: jest.fn(() => Promise.resolve()),
         appendFile: jest.fn(() => Promise.resolve()),
       }));
@@ -65,24 +65,21 @@ describe('logger', () => {
       await import('../../utils/logger');
 
       // Get the mocked fs module
-      const mockedFs = await import('node:fs/promises');
+      fs = await import('node:fs/promises');
 
-      // Wait for async initialization - increased timeout for CI stability
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
-      expect(mockedFs.mkdir).toHaveBeenCalledWith(
-        expect.stringContaining('logs'),
-        {
-          recursive: true,
-        },
-      );
-    }, 15000); // Increase test timeout
+      expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining('logs'), {
+        recursive: true,
+      });
+    });
 
     it('should handle directory creation errors gracefully', async () => {
       const mkdirError = new Error('Permission denied');
 
       // Set up mocks
-      jest.doMock('node:fs/promises', () => ({
+      jest.doMock('fs/promises', () => ({
         mkdir: jest.fn(() => Promise.reject(mkdirError)),
         appendFile: jest.fn(() => Promise.resolve()),
       }));
@@ -90,14 +87,14 @@ describe('logger', () => {
       // Import the module
       await import('../../utils/logger');
 
-      // Wait for async initialization - increased timeout for CI stability
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Could not create log directory:',
         mkdirError,
       );
-    }, 15000); // Increase test timeout
+    });
   });
 
   describe('logToFile', () => {

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -57,7 +57,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/gmail.modify',
   'https://www.googleapis.com/auth/directory.readonly',
   'https://www.googleapis.com/auth/presentations.readonly',
-  'https://www.googleapis.com/auth/spreadsheets.readonly',
+  'https://www.googleapis.com/auth/spreadsheets',
 ];
 
 // Dynamically import version from package.json
@@ -497,6 +497,26 @@ async function main() {
       ...readOnlyToolProps,
     },
     sheetsService.getMetadata,
+  );
+
+  server.registerTool(
+    'sheets.insertText',
+    {
+      description:
+        'Inserts text or a value into a specific cell or range in a Google Sheets spreadsheet.',
+      inputSchema: {
+        spreadsheetId: z
+          .string()
+          .describe('The ID or URL of the spreadsheet to modify.'),
+        range: z
+          .string()
+          .describe(
+            'The A1 notation range to insert text into (e.g., "Sheet1!A1").',
+          ),
+        value: z.string().describe('The text or value to insert.'),
+      },
+    },
+    sheetsService.insertText,
   );
 
   server.registerTool(

--- a/workspace-server/src/services/SheetsService.ts
+++ b/workspace-server/src/services/SheetsService.ts
@@ -310,4 +310,59 @@ export class SheetsService {
       };
     }
   };
+
+  public insertText = async ({
+    spreadsheetId,
+    range,
+    value,
+  }: {
+    spreadsheetId: string;
+    range: string;
+    value: string;
+  }) => {
+    logToFile(
+      `[SheetsService] Starting insertText for spreadsheet: ${spreadsheetId}, range: ${range}`,
+    );
+    try {
+      const id = extractDocId(spreadsheetId) || spreadsheetId;
+
+      const sheets = await this.getSheetsClient();
+      const response = await sheets.spreadsheets.values.update({
+        spreadsheetId: id,
+        range: range,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values: [[value]],
+        },
+      });
+
+      logToFile(`[SheetsService] Finished insertText for spreadsheet: ${id}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              spreadsheetId: response.data.spreadsheetId,
+              updatedRange: response.data.updatedRange,
+              updatedCells: response.data.updatedCells,
+            }),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(
+        `[SheetsService] Error during sheets.insertText: ${errorMessage}`,
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
 }


### PR DESCRIPTION
Implemented the `sheets.insertText` tool to allow writing data to Google Sheets spreadsheets. Updated the service, tool registration, and OAuth scopes, and added relevant unit tests.

Fixes #8

---
*PR created automatically by Jules for task [13125415055850654377](https://jules.google.com/task/13125415055850654377) started by @raybell-md*